### PR TITLE
Create locking between Lambda containers

### DIFF
--- a/createHeliumPkgFile.js
+++ b/createHeliumPkgFile.js
@@ -10,6 +10,7 @@ var containerId = Date.now().toString().slice(-6)
 exports.handler = (event, context, callback) => {
   checkPreviousContainerId()
     .then(function (previousContainerId) {
+      console.log("Running at Lambda container " + containerId)
       if(previousContainerId !== containerId) {
         return removeContentInTmp()
       } else {
@@ -19,7 +20,7 @@ exports.handler = (event, context, callback) => {
     })
     .delay(3000)
     .then(function(){
-      console.log('Will take less than 10 sec to integrate whole package info in ' + containerId + " Lambda container...")
+      console.log("Will take less than 10 sec to integrate whole package info ...")
       return pushPkgInfoToTmp()
     })
     .delay(8000)

--- a/lib/createHeliumPkgFile/checkPreviousContainerId.js
+++ b/lib/createHeliumPkgFile/checkPreviousContainerId.js
@@ -1,0 +1,31 @@
+var AWS = require('aws-sdk')
+AWS.config.setPromisesDependency(require('bluebird'))
+var s3 = new AWS.S3(
+  {
+    signatureVersion: 'v4',
+    maxRetries: 0
+  }
+)
+
+function checkPreviousContainerId() {
+  const bucketName = 'helium-package'
+  const keyName = 'helium-metadata.json'
+
+  const params = {
+    Bucket: bucketName,
+    Key: keyName
+  }
+  var getObjectPromise = s3.getObject(params).promise()
+
+  return getObjectPromise
+    .then(function(data) {
+      var content = data.Body.toString()
+      var previousContainerId = JSON.parse(content).metaData._lambdaContainerId
+
+      return previousContainerId
+    })
+    .catch(function (error) {
+      console.log(error, error.stack)
+    })
+}
+module.exports = checkPreviousContainerId

--- a/lib/createHeliumPkgFile/createFinalHeliumFile.js
+++ b/lib/createHeliumPkgFile/createFinalHeliumFile.js
@@ -10,13 +10,12 @@ var s3 = new AWS.S3(
 var moment = require('moment')
 var stringify = require('json-stringify-pretty-compact')
 
-function createMetadataContent() {
+function createMetadataContent(containerId) {
   var currentTime = moment().format('YYYY-MM-DDThh:mm:ssZ')
-  var lambdaContainerId = Date.now().toString().slice(-6)
 
   var metaData = {
     _createdAt: currentTime,
-    _lambdaContainerId: lambdaContainerId
+    _lambdaContainerId: containerId
   }
 
   var metaDataJson = {
@@ -26,7 +25,7 @@ function createMetadataContent() {
   return stringify(metaDataJson)
 }
 
-function createFinalHeliumFile(result) {
+function createFinalHeliumFile(containerId, result) {
   const bucketName = 'helium-package'
   const heliumFileName = 'helium'
 
@@ -63,7 +62,7 @@ function createFinalHeliumFile(result) {
   var metaDataContent = {
     Bucket: bucketName,
     Key: heliumFileName + '-metadata.json',
-    Body: createMetadataContent(),
+    Body: createMetadataContent(containerId),
     ACL: 'public-read'
   }
   var putObjectPromiseForMetaData = s3.putObject(metaDataContent).promise()


### PR DESCRIPTION
@1ambda As you suggested I created a lock between Lambda containers. 

Let me briefly share the background history. 
As described in ["AWS Lambda Container Lifetime and Config Refresh"](https://www.linkedin.com/pulse/aws-lambda-container-lifetime-config-refresh-frederik-willaert), due to this reusing Lambda container mechanism, sometimes duplicated Helium pkgs are written again and again.  (as you sometimes noticed.. 😅)

With this patch, when [`helium.json`](https://s3.amazonaws.com/helium-package/helium.json)created below info will be saved under [`helium-metadata.json`](https://s3.amazonaws.com/helium-package/helium-metadata.json)
```
{
  "metaData": {
    "_createdAt": "2017-02-14T09:01:58+00:00",
    "_lambdaContainerId": "905149"
  }
}
```
Like you said in [this comment](https://github.com/apache/zeppelin/pull/1935#issuecomment-276862781), you can also check when `helium.json` was created with `_createdAt` value, 
The reason why I didn't directly added this `metaData` field to `helium.json` is to avoid changing Zeppelin source code. 

To sum up, if `_lambdaContainerId` (previous Lambda container id) and current one are same, then the running will be skipped. And will wait until the next trigger. 
![screen shot 2017-02-14 at 6 30 40 pm](https://cloud.githubusercontent.com/assets/10060731/22923198/c851621a-f2e3-11e6-942c-c31fa6656dcf.png)
